### PR TITLE
Bug fix in the arch port naming

### DIFF
--- a/ARCH/openfpga_arch_template/k4_frac_N8_reset_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/ARCH/openfpga_arch_template/k4_frac_N8_reset_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -181,7 +181,7 @@
       <port type="input" prefix="D" size="1"/>
       <port type="output" prefix="Q" size="1"/>
       <port type="clock" prefix="prog_clk" lib_name="CLK" size="1" is_global="true" default_val="0" is_prog="true"/>
-      <port type="input" prefix="prog_reset" lib_name="RESET_B" size="1" is_global="true" default_val="1" is_prog="true" is_reset="true"/> 
+      <port type="input" prefix="pReset" lib_name="RESET_B" size="1" is_global="true" default_val="1" is_prog="true" is_reset="true"/> 
     </circuit_model>
     <circuit_model type="iopad" name="EMBEDDED_IO_HD" prefix="EMBEDDED_IO_HD" is_default="true" verilog_netlist="${SKYWATER_OPENFPGA_HOME}/HDL/common/digital_io_hd.v">
       <design_technology type="cmos"/>

--- a/ARCH/openfpga_arch_template/k4_frac_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/ARCH/openfpga_arch_template/k4_frac_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -182,7 +182,7 @@
       <port type="input" prefix="D" size="1"/>
       <port type="output" prefix="Q" size="1"/>
       <port type="clock" prefix="prog_clk" lib_name="CLK" size="1" is_global="true" default_val="0" is_prog="true"/>
-      <port type="input" prefix="prog_reset" lib_name="RESET_B" size="1" is_global="true" default_val="1" is_prog="true" is_reset="true"/> 
+      <port type="input" prefix="pReset" lib_name="RESET_B" size="1" is_global="true" default_val="1" is_prog="true" is_reset="true"/> 
     </circuit_model>
     <circuit_model type="iopad" name="EMBEDDED_IO_HD" prefix="EMBEDDED_IO_HD" is_default="true" verilog_netlist="${SKYWATER_OPENFPGA_HOME}/HDL/common/digital_io_hd.v">
       <design_technology type="cmos"/>


### PR DESCRIPTION
Change `prog_reset` port name to `pReset` to avoid hitting a reserved word in OpenFPGA